### PR TITLE
WIP Implementation of peer credentials.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl UnixStream {
     }
 
     /// Returns effective credentials of the process which called `connect` or `socketpair`.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn peer_cred(&self) -> io::Result<UCred> {
         ucred::get_peer_cred(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,6 @@ impl UnixStream {
     }
 
     /// Returns effective credentials of the process which called `connect` or `socketpair`.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn peer_cred(&self) -> io::Result<UCred> {
         ucred::get_peer_cred(self)
     }

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -64,7 +64,7 @@ pub mod impl_macos {
 
             let mut cred: super::UCred = mem::uninitialized();
 
-            let ret = getpeereid(raw_fd, &mut cred.uid, &mut cred.pid);
+            let ret = getpeereid(raw_fd, &mut cred.uid, &mut cred.gid);
 
             if ret == 0 {
                 Ok(cred)

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -1,0 +1,57 @@
+use libc::{pid_t, uid_t, gid_t};
+
+/// Credentials of a process
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct UCred {
+    /// PID (process ID) of the process
+    pub pid: pid_t,
+    /// UID (user ID) of the process
+    pub uid: uid_t,
+    /// GID (group ID) of the process
+    pub gid: gid_t,
+}
+
+#[cfg(target_os = "linux")]
+pub use self::impl_linux::get_peer_cred;
+
+#[cfg(target_os = "linux")]
+pub mod impl_linux {
+    use libc::{pid_t, uid_t, gid_t, getsockopt, SOL_SOCKET, SO_PEERCRED, c_void};
+    use std::{io, mem};
+    use UnixStream;
+    use std::os::unix::io::AsRawFd;
+
+    #[repr(C)]
+    struct UCred {
+        pid: pid_t,
+        uid: uid_t,
+        gid: gid_t,
+    }
+
+    pub fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {
+        unsafe {
+            let raw_fd = sock.as_raw_fd();
+
+            let mut ucred: UCred = mem::uninitialized();
+
+            let ucred_size = mem::size_of::<UCred>();
+
+            // These paranoid checks should be optimized-out
+            assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
+            assert!(ucred_size <= u32::max_value() as usize);
+
+            let mut ucred_size = ucred_size as u32;
+            
+            let ret = getsockopt(raw_fd, SOL_SOCKET, SO_PEERCRED, &mut ucred as *mut UCred as *mut c_void, &mut ucred_size);
+            if ret == 0 && ucred_size as usize == mem::size_of::<UCred>() {
+                Ok(super::UCred {
+                    pid: ucred.pid,
+                    uid: ucred.uid,
+                    gid: ucred.gid,
+                })
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+}

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -1,10 +1,8 @@
-use libc::{pid_t, uid_t, gid_t};
+use libc::{uid_t, gid_t};
 
 /// Credentials of a process
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct UCred {
-    /// PID (process ID) of the process
-    pub pid: pid_t,
     /// UID (user ID) of the process
     pub uid: uid_t,
     /// GID (group ID) of the process
@@ -40,7 +38,6 @@ pub mod impl_linux {
             let ret = getsockopt(raw_fd, SOL_SOCKET, SO_PEERCRED, &mut ucred as *mut UCred as *mut c_void, &mut ucred_size);
             if ret == 0 && ucred_size as usize == mem::size_of::<UCred>() {
                 Ok(super::UCred {
-                    pid: ucred.pid,
                     uid: ucred.uid,
                     gid: ucred.gid,
                 })

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -74,3 +74,28 @@ pub mod impl_macos {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use tokio_core::reactor::Core;
+    use UnixStream;
+    use libc::geteuid;
+    use libc::getegid;
+
+    #[test]
+    fn test_socket_pair() {
+        let core = Core::new().unwrap();
+        let handle = core.handle();
+
+        let (a, b) = UnixStream::pair(&handle).unwrap();
+        let cred_a = a.peer_cred().unwrap();
+        let cred_b = b.peer_cred().unwrap();
+        assert_eq!(cred_a, cred_b);
+
+        let uid = unsafe { geteuid() };
+        let gid = unsafe { getegid() };
+
+        assert_eq!(cred_a.uid, uid);
+        assert_eq!(cred_a.gid, gid);
+    }
+}

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -16,17 +16,12 @@ pub use self::impl_linux::get_peer_cred;
 
 #[cfg(target_os = "linux")]
 pub mod impl_linux {
-    use libc::{pid_t, uid_t, gid_t, getsockopt, SOL_SOCKET, SO_PEERCRED, c_void};
+    use libc::{getsockopt, SOL_SOCKET, SO_PEERCRED, c_void};
     use std::{io, mem};
     use UnixStream;
     use std::os::unix::io::AsRawFd;
 
-    #[repr(C)]
-    struct UCred {
-        pid: pid_t,
-        uid: uid_t,
-        gid: gid_t,
-    }
+    use libc::ucred as UCred;
 
     pub fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {
         unsafe {


### PR DESCRIPTION
This implements peer credentials for `UnixStream`. Closes #12.

This is WIP now. It contains only Linux implementation (macOS coming soon). I published it now so I can have it reviewed to avoid huge rewrite.

I decided to name the method `peer_cred` instead of `get_peer_cred` to be consistent with other methods (e.g. `peer_addr`).

The implementation is based on one I found in [PostgreSQL](https://doxygen.postgresql.org/getpeereid_8c_source.html).
Relevant [SO question](https://stackoverflow.com/questions/9898961/is-there-a-way-to-get-the-uid-of-the-other-end-of-a-unix-socket-connection)

I think this might be added to `std` and then forward it but I think it'd be nice to use this crate as a testing ground.

Unresolved questions:

* Bikeshed names (I'm fairly confident about at least method name but I'm open to other suggestions.)
* Should I implement for Solaris too? I have nothing to test it on.
* Tests? (I don't see any tests in this crate but that doesn't mean there shouldn't be.)
* Is documentation sufficient?
* Someone else should probably review the `unsafe` code (it should be just syscall though, nothing complicated)
* ~~Should I define `#[repr(C)] struct UCred` manually or should it be somehow auto-generated? I didn't find it in `libc`. (Maybe PR against `libc?)~~ I found it. Fixed in e0da3a9d342115d2f87acb0534659347855381c4.
* Is this method applicable for other Unix sockets? (E.g. datagram.)