### PR TITLE
Disable ucred support on Android and Musl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,10 @@ use tokio_io::{IoStream, AsyncRead, AsyncWrite};
 
 mod frame;
 pub use frame::{UnixDatagramFramed, UnixDatagramCodec};
+
+#[cfg(not(target_os = "android"))]
 mod ucred;
+#[cfg(not(target_os = "android"))]
 pub use ucred::UCred;
 
 fn would_block() -> io::Error {
@@ -283,6 +286,7 @@ impl UnixStream {
         self.io.get_ref().peer_addr()
     }
 
+    #[cfg(not(target_os = "android"))]
     /// Returns effective credentials of the process which called `connect` or `socketpair`.
     pub fn peer_cred(&self) -> io::Result<UCred> {
         ucred::get_peer_cred(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@ use tokio_io::{IoStream, AsyncRead, AsyncWrite};
 mod frame;
 pub use frame::{UnixDatagramFramed, UnixDatagramCodec};
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "musl")))]
 mod ucred;
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "musl")))]
 pub use ucred::UCred;
 
 fn would_block() -> io::Error {
@@ -286,7 +286,7 @@ impl UnixStream {
         self.io.get_ref().peer_addr()
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_env = "musl")))]
     /// Returns effective credentials of the process which called `connect` or `socketpair`.
     pub fn peer_cred(&self) -> io::Result<UCred> {
         ucred::get_peer_cred(self)

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -51,7 +51,7 @@ pub mod impl_linux {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "android"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 pub mod impl_macos {
     use libc::getpeereid;
     use std::{io, mem};

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -51,7 +51,7 @@ pub mod impl_linux {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "android"))]
 pub mod impl_macos {
     use libc::getpeereid;
     use std::{io, mem};


### PR DESCRIPTION
Quick fix to make tokio-uds build again on Android by removing ucred support.

Ucred or getpeereid support doesn't seem to be in the libc crate, not sure if this is because the underlying libc doesn't support it.

See #18 