### PR TITLE
Fix build on DragonFly

### DIFF
--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -12,7 +12,7 @@ pub struct UCred {
 #[cfg(target_os = "linux")]
 pub use self::impl_linux::get_peer_cred;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 pub use self::impl_macos::get_peer_cred;
 
 #[cfg(target_os = "linux")]
@@ -51,7 +51,7 @@ pub mod impl_linux {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 pub mod impl_macos {
     use libc::getpeereid;
     use std::{io, mem};
@@ -75,6 +75,8 @@ pub mod impl_macos {
     }
 }
 
+// Note that SO_PEERCRED is not supported on DragonFly (yet). So do not run tests.
+#[cfg(not(target_os = "dragonfly"))]
 #[cfg(test)]
 mod test {
     use tokio_core::reactor::Core;


### PR DESCRIPTION
Note that DragonFly does not (yet) support SO_PEERCRED. Anyhow,
we use the same code here as MacOS and FreeBSD. The result is a
Result::Err at runtime when being called. Alternatively
UnixStream#peer_cred could be conditionally removed on DragonFly.