### PR TITLE
Async UnixStream::connect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 
 script:
   - cargo test
+  - cargo test --features unstable-futures
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,15 @@ appveyor = { repository = "alexcrichton/tokio-uds" }
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1.11"
+futures = "0.1"
+futures2 = { version = "0.1.0", optional = true }
 iovec = "0.1"
 libc = "0.2"
 log = "0.4"
-mio = "0.6.5"
+mio = "0.6.14"
 mio-uds = "0.6.4"
-tokio-core = "0.1"
+tokio-reactor = { git = "https://github.com/tokio-rs/tokio", features = ["unstable-futures"] }
 tokio-io = "0.1"
+
+[features]
+unstable-futures = ["futures2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,16 @@ appveyor = { repository = "alexcrichton/tokio-uds" }
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-futures2 = { version = "0.1.0", optional = true }
+futures-core = { version = "0.2.0-beta", optional = true }
+futures-io = { version = "0.2.0-beta", optional = true }
+futures-sink = { version = "0.2.0-beta", optional = true }
 iovec = "0.1"
 libc = "0.2"
 log = "0.4"
 mio = "0.6.14"
 mio-uds = "0.6.4"
-tokio-reactor = { git = "https://github.com/tokio-rs/tokio", features = ["unstable-futures"] }
+tokio-reactor = { version = "0.1.1", features = ["unstable-futures"] }
 tokio-io = "0.1"
 
 [features]
-unstable-futures = ["futures2"]
+unstable-futures = ["futures-core", "futures-io", "futures-sink"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-uds"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tokio-rs/tokio-uds"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ appveyor = { repository = "alexcrichton/tokio-uds" }
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-futures-core = { version = "0.2.0-beta", optional = true }
-futures-io = { version = "0.2.0-beta", optional = true }
-futures-sink = { version = "0.2.0-beta", optional = true }
+futures-core = { version = "=0.2.0-beta", optional = true }
+futures-io = { version = "=0.2.0-beta", optional = true }
+futures-sink = { version = "=0.2.0-beta", optional = true }
 iovec = "0.1"
 libc = "0.2"
 log = "0.4"
 mio = "0.6.14"
 mio-uds = "0.6.4"
-tokio-reactor = { version = "0.1.1", features = ["unstable-futures"] }
+tokio-reactor = { version = "0.1.1" }
 tokio-io = "0.1"
 
 [features]
-unstable-futures = ["futures-core", "futures-io", "futures-sink"]
+unstable-futures = ["futures-core", "futures-io", "futures-sink", "tokio-reactor/unstable-futures"]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -6,6 +6,8 @@ use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 #[cfg(feature = "unstable-futures")]
 use futures2::{self, task};
+#[cfg(feature = "unstable-futures")]
+use futures_sink;
 
 use UnixDatagram;
 
@@ -142,7 +144,7 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
 }
 
 #[cfg(feature = "unstable-futures")]
-impl<C: UnixDatagramCodec> futures2::Sink for UnixDatagramFramed<C> {
+impl<C: UnixDatagramCodec> futures_sink::Sink for UnixDatagramFramed<C> {
     type SinkItem = C::Out;
     type SinkError = io::Error;
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::os::unix::net::SocketAddr;
 use std::path::PathBuf;
 
-use futures::{Async, Poll, Stream, Sink, StartSend, AsyncSink};
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 use UnixDatagram;
 
@@ -50,8 +50,7 @@ pub trait UnixDatagramCodec {
     ///
     /// The encode method also determines the destination to which the buffer
     /// should be directed, which will be returned as a `SocketAddr`.
-    fn encode(&mut self, msg: Self::Out, buf: &mut Vec<u8>)
-              -> io::Result<PathBuf>;
+    fn encode(&mut self, msg: Self::Out, buf: &mut Vec<u8>) -> io::Result<PathBuf>;
 }
 
 /// A unified `Stream` and `Sink` interface to an underlying
@@ -101,7 +100,7 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         trace!("flushing framed transport");
 
         if self.wr.is_empty() {
-            return Ok(Async::Ready(()))
+            return Ok(Async::Ready(()));
         }
 
         trace!("writing; remaining={}", self.wr.len());
@@ -112,8 +111,10 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         if wrote_all {
             Ok(Async::Ready(()))
         } else {
-            Err(io::Error::new(io::ErrorKind::Other,
-                               "failed to write entire datagram to socket"))
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            ))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,15 @@ pub struct UnixListener {
 
 impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified path.
-    pub fn bind<P>(path: P, handle: Handle) -> io::Result<UnixListener>
+    pub fn bind<P>(path: P) -> io::Result<UnixListener>
+    where
+        P: AsRef<Path>,
+    {
+        UnixListener::bind_handle(path.as_ref(), Handle::default())
+    }
+
+    /// Creates a new `UnixListener` bound to the specified path.
+    pub fn bind_handle<P>(path: P, handle: Handle) -> io::Result<UnixListener>
     where
         P: AsRef<Path>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,11 @@ impl UnixListener {
     }
 
     /// Test whether this socket is ready to be read or not.
+    pub fn poll_read_ready(&self, ready: Ready) -> Poll<Ready, io::Error> {
+        self.io.poll_read_ready(ready)
+    }
+
+    /// Test whether this socket is ready to be read or not.
     #[cfg(feature = "unstable-futures")]
     pub fn poll_read_ready2(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,11 @@ extern crate bytes;
 #[macro_use]
 extern crate futures;
 #[cfg(feature = "unstable-futures")]
-extern crate futures2;
+extern crate futures_core as futures2;
+#[cfg(feature = "unstable-futures")]
+extern crate futures_io;
+#[cfg(feature = "unstable-futures")]
+extern crate futures_sink;
 extern crate iovec;
 extern crate libc;
 #[macro_use]
@@ -437,13 +441,13 @@ impl<'a> Write for &'a UnixStream {
 }
 
 #[cfg(feature = "unstable-futures")]
-impl futures2::io::AsyncRead for UnixStream {
+impl futures_io::AsyncRead for UnixStream {
     fn poll_read(
         &mut self,
         cx: &mut task::Context,
         buf: &mut [u8],
     ) -> futures2::Poll<usize, io::Error> {
-        futures2::io::AsyncRead::poll_read(&mut &*self, cx, buf)
+        futures_io::AsyncRead::poll_read(&mut &*self, cx, buf)
     }
 
     fn poll_vectored_read(
@@ -451,22 +455,22 @@ impl futures2::io::AsyncRead for UnixStream {
         cx: &mut task::Context,
         vec: &mut [&mut IoVec],
     ) -> futures2::Poll<usize, io::Error> {
-        futures2::io::AsyncRead::poll_vectored_read(&mut &*self, cx, vec)
+        futures_io::AsyncRead::poll_vectored_read(&mut &*self, cx, vec)
     }
 
-    unsafe fn initializer(&self) -> futures2::io::Initializer {
-        futures2::io::AsyncRead::initializer(&self.io)
+    unsafe fn initializer(&self) -> futures_io::Initializer {
+        futures_io::AsyncRead::initializer(&self.io)
     }
 }
 
 #[cfg(feature = "unstable-futures")]
-impl<'a> futures2::io::AsyncRead for &'a UnixStream {
+impl<'a> futures_io::AsyncRead for &'a UnixStream {
     fn poll_read(
         &mut self,
         cx: &mut task::Context,
         buf: &mut [u8],
     ) -> futures2::Poll<usize, io::Error> {
-        (&self.io).poll_read(cx, buf)
+        futures_io::AsyncRead::poll_read(&mut &self.io, cx, buf)
     }
 
     fn poll_vectored_read(
@@ -493,19 +497,19 @@ impl<'a> futures2::io::AsyncRead for &'a UnixStream {
         }
     }
 
-    unsafe fn initializer(&self) -> futures2::io::Initializer {
-        futures2::io::AsyncRead::initializer(&self.io)
+    unsafe fn initializer(&self) -> futures_io::Initializer {
+        futures_io::AsyncRead::initializer(&self.io)
     }
 }
 
 #[cfg(feature = "unstable-futures")]
-impl futures2::io::AsyncWrite for UnixStream {
+impl futures_io::AsyncWrite for UnixStream {
     fn poll_write(
         &mut self,
         cx: &mut task::Context,
         buf: &[u8],
     ) -> futures2::Poll<usize, io::Error> {
-        (&self.io).poll_write(cx, buf)
+        futures_io::AsyncWrite::poll_write(&mut &*self, cx, buf)
     }
 
     fn poll_vectored_write(
@@ -517,22 +521,22 @@ impl futures2::io::AsyncWrite for UnixStream {
     }
 
     fn poll_flush(&mut self, cx: &mut task::Context) -> futures2::Poll<(), io::Error> {
-        (&self.io).poll_flush(cx)
+        futures_io::AsyncWrite::poll_flush(&mut &*self, cx)
     }
 
     fn poll_close(&mut self, cx: &mut task::Context) -> futures2::Poll<(), io::Error> {
-        (&self.io).poll_close(cx)
+        futures_io::AsyncWrite::poll_close(&mut &*self, cx)
     }
 }
 
 #[cfg(feature = "unstable-futures")]
-impl<'a> futures2::io::AsyncWrite for &'a UnixStream {
+impl<'a> futures_io::AsyncWrite for &'a UnixStream {
     fn poll_write(
         &mut self,
         cx: &mut task::Context,
         buf: &[u8],
     ) -> futures2::Poll<usize, io::Error> {
-        (&self.io).poll_write(cx, buf)
+        futures_io::AsyncWrite::poll_write(&mut &self.io, cx, buf)
     }
 
     fn poll_vectored_write(
@@ -560,11 +564,11 @@ impl<'a> futures2::io::AsyncWrite for &'a UnixStream {
     }
 
     fn poll_flush(&mut self, cx: &mut task::Context) -> futures2::Poll<(), io::Error> {
-        (&self.io).poll_flush(cx)
+        futures_io::AsyncWrite::poll_flush(&mut &self.io, cx)
     }
 
     fn poll_close(&mut self, cx: &mut task::Context) -> futures2::Poll<(), io::Error> {
-        (&self.io).poll_close(cx)
+        futures_io::AsyncWrite::poll_close(&mut &self.io, cx)
     }
 }
 

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -40,7 +40,7 @@ pub mod impl_linux {
             assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
             assert!(ucred_size <= u32::max_value() as usize);
 
-            let mut ucred_size = ucred_size as u32;
+            let mut ucred_size = ucred_size as socklen_t;
 
             let ret = getsockopt(
                 raw_fd,
@@ -89,14 +89,14 @@ pub mod impl_macos {
 #[cfg(not(target_os = "dragonfly"))]
 #[cfg(test)]
 mod test {
-    use tokio_core::reactor::Core;
+    use tokio_reactor::Reactor;
     use UnixStream;
     use libc::geteuid;
     use libc::getegid;
 
     #[test]
     fn test_socket_pair() {
-        let core = Core::new().unwrap();
+        let core = Reactor::new().unwrap();
         let handle = core.handle();
 
         let (a, b) = UnixStream::pair(&handle).unwrap();


### PR DESCRIPTION
Fixes #1, and is a significant breaking change.

This PR is built on top of #29 and will probably need a rebase after that is merged. The implementation was mostly lifted from `tokio-tcp`.

Although this handles the `EINPROGRESS` case for `connect()` (with an additional modification to `mio-uds` required I believe), I'm not sure how to (or whether it's possible to?) handle `EAGAIN/EWOULDBLOCK` properly...