### PR TITLE
Upgrade tokio_core dependency to use tokio 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-uds"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tokio-rs/tokio-uds"
@@ -17,11 +17,12 @@ appveyor = { repository = "alexcrichton/tokio-uds" }
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1.11"
+futures = "0.1"
 iovec = "0.1"
 libc = "0.2"
 log = "0.4"
-mio = "0.6.5"
+mio = "0.6.14"
 mio-uds = "0.6.4"
-tokio-core = "0.1"
+tokio-reactor = "0.1.1"
 tokio-io = "0.1"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ iovec = "0.1"
 libc = "0.2"
 log = "0.4"
 mio = "0.6.14"
-mio-uds = "0.6.4"
+mio-uds = "0.6.5"
 tokio-reactor = "0.1.1"
 tokio-io = "0.1"
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -72,7 +72,7 @@ impl<C: UnixDatagramCodec> Stream for UnixDatagramFramed<C> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<C::In>, io::Error> {
-        let (n, addr) = try_ready!(self.socket.recv_from(&mut self.rd));
+        let (n, addr) = try_ready!(self.socket.poll_recv_from(&mut self.rd));
         trace!("received {} bytes, decoding", n);
         let frame = try!(self.codec.decode(&addr, &self.rd[..n]));
         trace!("frame decoded from buffer");
@@ -104,7 +104,7 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         }
 
         trace!("writing; remaining={}", self.wr.len());
-        let n = try_ready!(self.socket.send_to(&self.wr, &self.out_addr));
+        let n = try_ready!(self.socket.poll_send_to(&self.wr, &self.out_addr));
         trace!("written {}", n);
         let wrote_all = n == self.wr.len();
         self.wr.clear();

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::os::unix::net::SocketAddr;
 use std::path::PathBuf;
 
-use futures::{Async, Poll, Stream, Sink, StartSend, AsyncSink};
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 use UnixDatagram;
 
@@ -50,8 +50,7 @@ pub trait UnixDatagramCodec {
     ///
     /// The encode method also determines the destination to which the buffer
     /// should be directed, which will be returned as a `SocketAddr`.
-    fn encode(&mut self, msg: Self::Out, buf: &mut Vec<u8>)
-              -> io::Result<PathBuf>;
+    fn encode(&mut self, msg: Self::Out, buf: &mut Vec<u8>) -> io::Result<PathBuf>;
 }
 
 /// A unified `Stream` and `Sink` interface to an underlying
@@ -101,7 +100,7 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         trace!("flushing framed transport");
 
         if self.wr.is_empty() {
-            return Ok(Async::Ready(()))
+            return Ok(Async::Ready(()));
         }
 
         trace!("writing; remaining={}", self.wr.len());
@@ -112,8 +111,10 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         if wrote_all {
             Ok(Async::Ready(()))
         } else {
-            Err(io::Error::new(io::ErrorKind::Other,
-                               "failed to write entire datagram to socket"))
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            ))
         }
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -72,7 +72,7 @@ impl<C: UnixDatagramCodec> Stream for UnixDatagramFramed<C> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<C::In>, io::Error> {
-        let (n, addr) = try_nb!(self.socket.recv_from(&mut self.rd));
+        let (n, addr) = try_ready!(self.socket.recv_from(&mut self.rd));
         trace!("received {} bytes, decoding", n);
         let frame = try!(self.codec.decode(&addr, &self.rd[..n]));
         trace!("frame decoded from buffer");
@@ -104,7 +104,7 @@ impl<C: UnixDatagramCodec> Sink for UnixDatagramFramed<C> {
         }
 
         trace!("writing; remaining={}", self.wr.len());
-        let n = try_nb!(self.socket.send_to(&self.wr, &self.out_addr));
+        let n = try_ready!(self.socket.send_to(&self.wr, &self.out_addr));
         trace!("written {}", n);
         let wrote_all = n == self.wr.len();
         self.wr.clear();

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -40,7 +40,7 @@ pub mod impl_linux {
             assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
             assert!(ucred_size <= u32::max_value() as usize);
 
-            let mut ucred_size = ucred_size as u32;
+            let mut ucred_size = ucred_size as socklen_t;
 
             let ret = getsockopt(
                 raw_fd,
@@ -89,14 +89,14 @@ pub mod impl_macos {
 #[cfg(not(target_os = "dragonfly"))]
 #[cfg(test)]
 mod test {
-    use tokio_core::reactor::Core;
+    use tokio_reactor::Reactor;
     use UnixStream;
     use libc::geteuid;
     use libc::getegid;
 
     #[test]
     fn test_socket_pair() {
-        let core = Core::new().unwrap();
+        let core = Reactor::new().unwrap();
         let handle = core.handle();
 
         let (a, b) = UnixStream::pair(&handle).unwrap();


### PR DESCRIPTION
#29 grew into a huge PR due to my attempt to add in futures-0.2 support as well making it really though to review. This PR breaks out the tokio 0.1 changes as futures-0.2 is an unstable version whereas tokio 0.1 is something that is more likely to be used.

Hopefully this should be easier to review, it is still based on top of #32 as I believe that should be a straightforward merge.