### PR TITLE
`UnixStream::connect` should return a future

### DIFF
--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -40,7 +40,7 @@ fn echo() {
             .map_err(|e| panic!("err={:?}", e))
     });
 
-    let client = UnixStream::connect(&sock_path).unwrap();
+    let client = rt.block_on(UnixStream::connect(&sock_path)).unwrap();
     let server = rt.block_on(rx).unwrap();
 
     // Write to the client


### PR DESCRIPTION
Unix domain sockets do not guarantee that a connect will complete
immediately. There are some cases in which they complete asynchronously.
Because of this, the connect operation must be represented as an
asynchronous operation.

Closes #1